### PR TITLE
Add v4.3

### DIFF
--- a/versions.js
+++ b/versions.js
@@ -36,6 +36,7 @@ function filter (published) {
   add(max('4'))
   add(max('<' + last()))
   add(max('<' + last()))
+  add(max('4.3')) // for AWS Lambda
   add(max('0.12'))
   add(max('0.10'))
 


### PR DESCRIPTION
I'd like to add v4.3 to compat table, because it's used in AWS Lambda.
http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html
