### PR TITLE
Website title and README update with ES2016 and ES2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ flavors out there. What I **do** need are deeper insights in the variations acro
 of Node.js. So, I created [node-compat-table](https://williamkapke.github.io/node-compat-table/).
 
 It works by [running a script](https://github.com/williamkapke/node-compat-table/blob/gh-pages/test.sh) that imports the
-latest set of <s>ES6</s> ES2015 tests from the [compat-table](https://github.com/kangax/compat-table) project and running
+latest set of <s>ES6</s> ES2015, ES2016 and ES2017 tests from the [compat-table](https://github.com/kangax/compat-table) project and running
 them against [several versions](https://github.com/williamkapke/node-compat-table/blob/gh-pages/v8.versions) of node PLUS
 [the nightly build](https://nodejs.org/download/nightly/). The results are committed/published here.
 

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Node.js ES2015/ES6 support
+    <title>Node.js ES2015/ES6, ES2016 and ES2017 support
     </title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link href="https://fonts.googleapis.com/css?family=Raleway:400,700" rel="stylesheet" type="text/css">

--- a/index.jade
+++ b/index.jade
@@ -3,7 +3,7 @@ html
   head
     title
       block title
-      | Node.js ES2015/ES6 support
+      | Node.js ES2015/ES6, ES2016 and ES2017 support
     meta(http-equiv="Content-Type",content="text/html; charset=utf-8")
     link(href='https://fonts.googleapis.com/css?family=Raleway:400,700',rel='stylesheet',type='text/css')
     link(href='favico.ico',rel='shortcut icon')


### PR DESCRIPTION
This PR updates the website title and the README with ES2016 and ES2017.
Currently both the website title and README contain only ES2015.
This fixes issue #36.