### PR TITLE
Use accessible colors and contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -85,7 +85,7 @@ body.scrolled .headings {
   top: -2px;
 }
 .version sup {
-  color: gold;
+  color: #f2e646;
   position: absolute;
   top: -15px;
   left: 0;
@@ -161,14 +161,14 @@ article > header > h1 a:hover {
   min-width: 65px;
 }
 .version {
-  cursor: pointer;
+  cursor: help;
   font-size: 16px;
   padding: 3px 0;
   color: white;
   position: relative;
   vertical-align: top;
   line-height: 16px;
-  background-color: #5b5bef;
+  background-color: #075c8d;
 }
 .details {
   padding: 6px;
@@ -178,7 +178,7 @@ article > header > h1 a:hover {
   right: 0;
   font-weight: normal;
   background-color: #454545;
-  color: #aaa;
+  color: #eee;
   width: 240px;
   border-radius: 9px;
 }
@@ -210,27 +210,28 @@ sub {
 }
 .subsub {
   text-indent: 10px;
-  color: #aaa
+  color: #555;
 }
 
 .Yes.flagged.required:before {
   content: '⚐';
   position: absolute;
   margin-left: 26px;
-  color: #666;
+  color: #444;
 }
 .Yes.flagged.required {
-  background-color: gold;
-  color: #666;
+  background-color: #f2e646;
+  color: #444;
 }
 .Yes {
-  background-color: #026e00;
+  background-color: #00aD7f;
+  color: black;
 }
 .No {
-  background-color: red;
+  background-color: #8e411a;
 }
 .Error {
-  background-color: #dd0000;
+  background-color: #8e411a;
 }
 
 .fn {
@@ -253,7 +254,7 @@ sub {
 .info {
   border-radius: 9px;
   background-color: #eee;
-  color: #aaa;
+  color: #444;
   float: right;
   text-align: center;
   font-size: 12px;
@@ -261,7 +262,7 @@ sub {
   height: 18px;
   text-indent: 0;
   line-height: 18px;
-  cursor: pointer;
+  cursor: help;
 }
 .info:hover .fn {
   display: inline-block;


### PR DESCRIPTION
The current colors and contrast pose a problem for people with color blindness.

Notice how the site looks for people with deuteranomaly and with protanomaly. It's difficult to visually determine the difference between supported (green) and not supported (red).

![](https://i.imgur.com/zAKBQZw.gif)

Using a modified version of a [conservative 7-color palette for color blindness](http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.trivial.png), I've come up with the following new look for node.green.

![](https://i.imgur.com/DVSqtyS.png)

Here's how it looks for people with color blindness. Note the clear distinction between supported and not supported.

![](https://i.imgur.com/1cCuO9r.gif)

In addition to the obvious color changes, I've included changes to some font colors to achieve [WCAG AAA contrast](https://www.w3.org/TR/WCAG20/#visual-audio-contrast7) for all text.

![](https://i.imgur.com/lqHLjRf.gif)

Also, hovering over version numbers and help icons uses `cursor: help` instead of `cursor: pointer`.

Fixes #41, fixes #5, fixes #56