### PR TITLE
Link to spec while allowing anchor copying

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -14,14 +14,23 @@ tests.forEach(function (test) {
   }
 
   var name = [category, test.name]
+  var info = {
+    spec: test.spec
+  }
 
   if (test.subtests) {
     test.subtests.forEach(function (subtest) {
       name[2] = subtest.name
-      testers[name.join('›').replace(/<[^>]+>/g, '')] = getScript(subtest.exec)
+      testers[name.join('›').replace(/<[^>]+>/g, '')] = {
+        ...info,
+        code: getScript(subtest.exec)
+      }
     })
   } else {
-    testers[name.join('›').replace(/<[^>]+>/g, '')] = getScript(test.exec)
+    testers[name.join('›').replace(/<[^>]+>/g, '')] = {
+      ...info,
+      code: getScript(test.exec)
+    }
   }
 
   function getScript (fn) {

--- a/index.pug
+++ b/index.pug
@@ -75,7 +75,8 @@ body
               tr
                 td.feature.subsub
                   .hash(id=subsubcategory2)
-                  a(href='#'+subsubcategory2)=subsubcategory
+                  a.anchor(href='#'+subsubcategory2) §
+                  a(href=obj3.spec)=subsubcategory
                   if obj3.code
                     .info
                       | ?

--- a/style.css
+++ b/style.css
@@ -274,3 +274,11 @@ table.results {
   position: absolute;
   margin-top: -46px;
 }
+.anchor {
+  margin-right: 5px;
+  font-size: 90%;
+  visibility: hidden;
+}
+tr:hover > td > .anchor {
+  visibility: visible;
+}

--- a/test.js
+++ b/test.js
@@ -56,7 +56,7 @@ function next (ver) {
     _percent: 0
   }
   Object.keys(testers[ver]).forEach(function (name) {
-    var script = testers[ver][name]
+    var script = testers[ver][name].code
     results[name] = false // make SURE it makes it to the output
 
     run(script, function (result) {

--- a/utils.js
+++ b/utils.js
@@ -41,9 +41,15 @@ module.exports = {
     var _testers = require('./testers.json')
     Object.keys(_testers).forEach((esVersion) => {
       testers[esVersion] = {}
-      Object.keys(_testers[esVersion]).forEach((path) =>
-        $set(testers[esVersion], path, {path: path, code: _testers[esVersion][path]})
-      )
+      Object.keys(_testers[esVersion]).forEach((path) => {
+        var item = _testers[esVersion][path]
+
+        $set(testers[esVersion], path, {
+          path: path,
+          spec: item.spec,
+          code: item.code
+        })
+      })
     })
     return testers
   },


### PR DESCRIPTION
Closes #64. 

Adding the spec link to the category would require a large refactor so I've added the link to the individual sub cases. 

Visit https://matthiaskunnen.github.io/node-compat-table/ to see how it looks.

@williamkapke