### PR TITLE
Improve learning new ES features experience

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -19,6 +19,8 @@ body
     label(for='flagged') requires&nbsp;
       a(href='https://nodejs.org/en/docs/es6/', target="_blank") harmony
       | &nbsp;flag ⚐
+    input#showInfoCode(type='checkbox')
+    label(for='showInfoCode') show code examples
   #credits
     | Created by&nbsp;
     a(href='https://github.com/williamkapke', target="_blank") William Kapke
@@ -87,7 +89,14 @@ body
                 each nodeVersion in Object.keys(headers)
                   - classes = requiresFlag(nodeVersion, esVersion, obj3.path)? 'flag' : ''
                   td.result(class=classes) !{results(nodeVersion, esVersion, obj3.path)}
-
+              if obj3.code
+                tr.codeExample
+                  td
+                  td(colspan=Object.keys(headers).length)
+                    .fn
+                      | function(){
+                      .code=obj3.code
+                      | }
 
   +article('ES2015')
   +article('ES2016')

--- a/style.css
+++ b/style.css
@@ -45,6 +45,7 @@ label[for=flagged] {
   top: 2px;
 }
 label[for=flagged],
+label[for=showInfoCode],
 #credits {
   z-index: 101;
   position: fixed;
@@ -107,6 +108,35 @@ body.scrolled .headings {
 #flagged ~ article .unflagged,
 #flagged ~ header .unflagged { display:block; }
 
+#showInfoCode {
+  position: fixed;
+  z-index: 101;
+  top: 0;
+  right: 510px;
+}
+
+label[for=showInfoCode] {
+  cursor: pointer;
+  right: 390px;
+  font-size: 12px;
+  top: 2px;
+}
+
+#showInfoCode:checked ~ article .info {
+  display: none;
+}
+
+#showInfoCode:checked ~ article tr.codeExample {
+  display: table-row;
+  position: relative;
+}
+
+#showInfoCode:checked ~ article tr.codeExample .fn {
+  position: relative;
+  display: block;
+  z-index: initial;
+  margin-left: 0px;
+}
 
 article {
   position: relative;


### PR DESCRIPTION
There are two reason to open node.green:
1. Check if some feature is available at some node version;
2. Discover new JS features.

For *2*, feature name, isn't always expressive enough, and for newbies hover every line isn't cool.

This changes, add new flag at header where users can show/hide code examples, they are displayed as new table line after feature.

[PR Version](https://hugosenari.github.io/node-compat-table/index.html)
