### PR TITLE
feat: add filtering node versions

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -15,6 +15,8 @@ html
 
       gtag('config', 'G-07N0XX7S5Z');
     link(rel="stylesheet", href="style.css")
+    link(rel="stylesheet" href="https://unpkg.com/multiple-select@1.7.0/dist/multiple-select.min.css")
+    script(src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous")
 body
   if (flaggable)
     input#flagged(type='checkbox')
@@ -26,6 +28,8 @@ body
   #credits
     | Created by&nbsp;
     a(href='https://github.com/williamkapke', target="_blank") William Kapke
+  div.select-version
+    select#select-version(multiple)
 
   header.global
     a#node-compat-logo(href='./')
@@ -102,3 +106,47 @@ body
 
   each version in Object.keys(testers)
     +article(version)
+  script(src="https://unpkg.com/multiple-select@1.7.0/dist/multiple-select.min.js")
+  script.
+    const nodeVersions = [...new Set($('th.version').contents().filter((i,n) => n.nodeType===3 && n.textContent.trim()).map((i,e) => e.textContent.trim()).toArray())]
+    
+    function toggleNodeVersion(option, selected) {
+      if (option === 'all') {
+        document.querySelectorAll('th.version,td.result').forEach(el => {
+            el.style.display = '';
+        })
+        localStorage.setItem('visible-versions', JSON.stringify(nodeVersions))
+      }
+      if (option === 'none') {
+        document.querySelectorAll('th.version,td.result').forEach(el => {
+            el.style.display = 'none';
+        })
+        localStorage.setItem('visible-versions', '[]')
+      }
+      if (typeof option === 'number') {
+        document .querySelectorAll(`th.version:nth-child(${option+1}), td.result:nth-child(${option+2})`)
+          .forEach(el => {
+            el.style.display = selected ? '' : 'none';
+          })
+        let visibleVersions = JSON.parse(localStorage.getItem('visible-versions', 'null')) || nodeVersions
+        if (selected) visibleVersions.push(nodeVersions[option])
+        else visibleVersions = visibleVersions.filter(v => v!== nodeVersions[option])
+        localStorage.setItem('visible-versions', JSON.stringify([ ...new Set(visibleVersions) ]))
+      }
+    }
+    const visibleVersions = new Set(JSON.parse(localStorage.getItem('visible-versions', 'null')) || nodeVersions)
+    function initVisibleVersions() {
+      const visibleVersions = new Set(JSON.parse(localStorage.getItem('visible-versions', 'null')) || nodeVersions)
+      nodeVersions.forEach((v,i) => {
+        toggleNodeVersion(i, visibleVersions.has(v))
+      })
+    }
+    initVisibleVersions()
+    const selectNodeEl = $('select#select-version').multipleSelect({
+      placeholder: 'Node Versions',
+      data: nodeVersions.map((text, i) => ({ text, value: i, selected: visibleVersions.has(text) })),
+      onClick: (args) => toggleNodeVersion(args.value, args.selected),
+      onCheckAll: () => toggleNodeVersion('all'),
+      onUncheckAll: () => toggleNodeVersion('none'),
+    })
+

--- a/style.css
+++ b/style.css
@@ -46,6 +46,7 @@ label[for=flagged] {
 }
 label[for=flagged],
 label[for=showInfoCode],
+div.select-version,
 #credits {
   z-index: 101;
   position: fixed;
@@ -311,4 +312,26 @@ table.results {
 }
 tr:hover > td > .anchor {
   visibility: visible;
+}
+
+select#select-version {
+  right: 600px;
+  width: 150px;
+}
+select[multiple] {
+  height: 16px;
+}
+select[multiple]:focus {
+  height: auto;
+}
+div.select-version {
+  right: 540px;
+  font-size: 12px;
+}
+button.ms-choice {
+  height: 16px;
+}
+button.ms-choice > span {
+  font-size: 14px;
+  line-height: 14px;
 }


### PR DESCRIPTION
Add feature to filter node versions.

Usecase:
> We upgraded from Node 14 to Node 20 recently. I wanted a concise list of differences between Node 14 & Node 20 only.
> This feature allows me to restrict the visible columns.

![image](https://github.com/user-attachments/assets/6f31730f-b51d-4400-99b4-51ee4eca2661)

---
Future scope:
* Allow filtering the rows based on certain rules. Example `Node 20.x = Yes and Node 14.x != Yes`
   I tried few ideas for this like
   *  [searchBuilder](https://datatables.net/extensions/staterestore/examples/integration/searchBuilder) feature of 
      [jquery datatables](https://datatables.net/download/index). This works and brings all the features of datatables but the page design changes entirely. Fixing the style is being too much effort.
      
![image](https://github.com/user-attachments/assets/95a5ee1b-19eb-4b8e-90f6-9fec7bea755a)

   * [jquery queryBuilder](https://querybuilder.js.org/demo.html). Favouring this as it can be integrated into the normal app, without using datatables. Might push a PR in near future.
      ![image](https://github.com/user-attachments/assets/031b2e6a-81c0-44ef-9ced-9e8bda9c2522)
